### PR TITLE
feat(nav): Phase 3 — Navigation Rework

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { open } from '@tauri-apps/plugin-dialog'
 import { preloadUtilSidecar } from '~/services/claude-process'
 import { installBundledPresets } from '~/services/flow-loader'
 
@@ -17,28 +16,18 @@ const cardsStore = useCardsStore()
 const pipelinesStore = usePipelinesStore()
 const sessionsStore = useSessionsStore()
 const { activeFile, closeFile } = useFileViewer()
+const { addProject } = useProjectActions()
 
 const appReady = ref(false)
+
+// NAV: activeTab lives in projectsStore so sessions store can derive per-project chat correctly
+const { activeTab, isProjectTab } = storeToRefs(projectsStore)
+
 const showSettings = ref(false)
-const showGlobalSettings = ref(false)
-const showChat = computed(() => sessionsStore.activeChatCardId !== null)
+const showChat = computed(() => isProjectTab.value && sessionsStore.activeChatCardId !== null)
 const isConsoleMode = computed(() => settingsStore.settings.chatMode === 'console')
 const chatWidth = ref(400)
 const consoleWidth = ref(520)
-
-async function addProject() {
-  try {
-    const selected = await open({ directory: true, multiple: false })
-    if (!selected) return
-    const path = typeof selected === 'string' ? selected : String(selected)
-    const name = path.split('/').filter(Boolean).pop() || 'project'
-    const project = await projectsStore.addProject(name, path)
-    await cardsStore.loadForProject(project.id)
-    await pipelinesStore.loadForProject(project.path)
-  } catch (err) {
-    console.error('[OnCraft] addProject error:', err)
-  }
-}
 
 function startResize(e: MouseEvent) {
   const startX = e.clientX
@@ -81,7 +70,9 @@ onMounted(async () => {
     return
   }
 
+  // NAV: Set initial tab to active project or home
   if (projectsStore.activeProject) {
+    projectsStore.activeTab = projectsStore.activeProject.id
     // QW-1: Cards and pipelines are independent — load in parallel
     await Promise.allSettled([
       cardsStore.loadForProject(projectsStore.activeProject.id),
@@ -105,27 +96,46 @@ onMounted(async () => {
     </Transition>
 
     <div v-show="appReady" id="app">
-      <TabBar @open-settings="showSettings = true" @open-global-settings="showGlobalSettings = true" />
+      <TabBar @open-project-settings="showSettings = true" />
       <div class="main-content" :class="{ 'with-chat': showChat }">
         <div class="board-area">
           <ErrorBoundary>
-            <FileViewer
-              v-if="activeFile && projectsStore.activeProject"
-              :label="activeFile.label"
-              :file-path="activeFile.path"
-              :project-path="projectsStore.activeProject.path"
-              @close="closeFile()"
-            />
-            <KanbanBoard v-else-if="projectsStore.activeProject" />
+            <!-- Home tab -->
             <EmptyState
-              v-else
-              icon="i-lucide-folder-open"
-              title="No project open"
+              v-if="activeTab === 'home'"
+              icon="i-lucide-house"
+              title="Welcome to OnCraft"
               description="Open a project folder to start managing your Claude Code sessions."
               action-label="Open project"
               action-icon="i-lucide-plus"
               @action="addProject"
             />
+
+            <!-- Settings tab (full-screen) -->
+            <GlobalSettings
+              v-else-if="activeTab === 'settings'"
+            />
+
+            <!-- Project tab: file viewer, kanban, or empty state -->
+            <template v-else>
+              <FileViewer
+                v-if="activeFile && projectsStore.activeProject"
+                :label="activeFile.label"
+                :file-path="activeFile.path"
+                :project-path="projectsStore.activeProject.path"
+                @close="closeFile()"
+              />
+              <KanbanBoard v-else-if="projectsStore.activeProject" />
+              <EmptyState
+                v-else
+                icon="i-lucide-folder-open"
+                title="No project open"
+                description="Open a project folder to start managing your Claude Code sessions."
+                action-label="Open project"
+                action-icon="i-lucide-plus"
+                @action="addProject"
+              />
+            </template>
           </ErrorBoundary>
         </div>
         <Transition name="chat-slide">
@@ -141,7 +151,6 @@ onMounted(async () => {
         </Transition>
       </div>
       <ProjectSettings v-if="showSettings" v-model:open="showSettings" @close="showSettings = false" />
-      <GlobalSettings v-if="showGlobalSettings" v-model:open="showGlobalSettings" @close="showGlobalSettings = false" />
     </div>
   </UApp>
 </template>

--- a/app/components/GlobalSettings.vue
+++ b/app/components/GlobalSettings.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
 import type { ChatMode } from '~/types';
 
-const open = defineModel<boolean>('open', { default: true });
-
-const emit = defineEmits<{ close: [] }>();
 const settingsStore = useSettingsStore();
 
 const chatModeOptions = [
@@ -18,17 +15,19 @@ const selectedChatMode = computed({
     settingsStore.save();
   },
 });
-
-function close() {
-  emit('close');
-  open.value = false;
-}
 </script>
 
 <template>
-  <UModal v-model:open="open" title="Global Settings" :ui="{ width: 'sm:max-w-[460px]' }" @update:open="(val: boolean) => { if (!val) close() }">
-    <template #body>
-      <div class="flex flex-col gap-4">
+  <div class="settings-page">
+    <div class="settings-header">
+      <UIcon name="i-lucide-settings" class="settings-header-icon" />
+      <h1 class="settings-title">Settings</h1>
+    </div>
+
+    <div class="settings-content">
+      <div class="settings-section">
+        <h2 class="section-title">General</h2>
+
         <div class="setting-group">
           <span class="setting-label">Chat Mode</span>
           <div class="chat-mode-options">
@@ -50,15 +49,36 @@ function close() {
               </div>
             </UButton>
           </div>
+          <p class="info-msg">Claude agent is bundled with the application. Console mode requires the Claude CLI to be installed.</p>
         </div>
-
-        <p class="info-msg">Claude agent is bundled with the application. Console mode requires the Claude CLI to be installed.</p>
       </div>
-    </template>
-  </UModal>
+    </div>
+  </div>
 </template>
 
 <style scoped>
+.settings-page {
+  height: 100%;
+  overflow-y: auto;
+  padding: 32px 40px;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+.settings-header-icon { font-size: 24px; color: var(--text-secondary); }
+.settings-title { font-size: 22px; font-weight: 700; color: var(--text-primary); margin: 0; }
+
+.settings-content { display: flex; flex-direction: column; gap: 32px; }
+
+.settings-section { display: flex; flex-direction: column; gap: 16px; }
+.section-title { font-size: 15px; font-weight: 600; color: var(--text-primary); margin: 0; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+
 .setting-group { display: flex; flex-direction: column; gap: 8px; }
 .setting-label { font-size: 13px; font-weight: 600; color: var(--text-primary); }
 

--- a/app/components/TabBar.vue
+++ b/app/components/TabBar.vue
@@ -1,67 +1,76 @@
 <script setup lang="ts">
-import { open } from '@tauri-apps/plugin-dialog';
+import { VueDraggable } from 'vue-draggable-plus';
+import type { Project } from '~/types';
 
 const projectsStore = useProjectsStore();
-const cardsStore = useCardsStore();
-const pipelinesStore = usePipelinesStore();
+const sessionsStore = useSessionsStore();
+const { addProject, switchToProject, closeProject } = useProjectActions();
 
-const emit = defineEmits<{ 'open-settings': []; 'open-global-settings': [] }>();
+const emit = defineEmits<{ 'open-project-settings': [] }>();
 
-async function switchProject(projectId: string) {
-  await projectsStore.setActive(projectId);
-  const project = projectsStore.activeProject;
-  if (project) {
-    await cardsStore.loadForProject(project.id);
-    await pipelinesStore.loadForProject(project.path);
-  }
-}
+// Local mutable copy for vue-draggable-plus (it needs to mutate the array during drag)
+const draggableProjects = ref<Project[]>([]);
+watch(() => projectsStore.projects, (newProjects) => {
+  draggableProjects.value = [...newProjects];
+}, { immediate: true });
 
-async function closeProject(projectId: string) {
-  await projectsStore.removeProject(projectId);
-  const active = projectsStore.activeProject;
-  if (active) {
-    await cardsStore.loadForProject(active.id);
-    await pipelinesStore.loadForProject(active.path);
-  }
-}
-
-async function addProject() {
-  try {
-    const selected = await open({ directory: true, multiple: false });
-    if (!selected) return;
-    const path = typeof selected === 'string' ? selected : String(selected);
-    const name = path.split('/').filter(Boolean).pop() || 'project';
-    const project = await projectsStore.addProject(name, path);
-    await cardsStore.loadForProject(project.id);
-    await pipelinesStore.loadForProject(project.path);
-  } catch (err) {
-    if (import.meta.dev) console.error('[OnCraft] addProject error:', err);
-  }
+function onDragEnd() {
+  const orderedIds = draggableProjects.value.map(p => p.id);
+  projectsStore.reorderProjects(orderedIds);
 }
 </script>
 
 <template>
   <div class="tab-bar">
-    <!-- Project tabs -->
+    <!-- Pinned: Home tab -->
     <div
-      v-for="project in projectsStore.projects"
-      :key="project.id"
-      class="tab"
-      :class="{ 'tab--active': project.id === projectsStore.activeProjectId }"
-      @click="switchProject(project.id)"
+      class="tab tab--pinned"
+      :class="{ 'tab--active': projectsStore.activeTab === 'home' }"
+      @click="projectsStore.activeTab = 'home'"
+      title="Home"
     >
-      <span class="tab-name">{{ project.name }}</span>
-      <UButton
-        variant="ghost"
-        color="neutral"
-        size="xs"
-        icon="i-lucide-x"
-        class="tab-close"
-        :padded="false"
-        @click.stop="closeProject(project.id)"
-        title="Close project"
-      />
+      <UIcon name="i-lucide-house" class="tab-icon" />
     </div>
+
+    <!-- Pinned: Settings tab -->
+    <div
+      class="tab tab--pinned"
+      :class="{ 'tab--active': projectsStore.activeTab === 'settings' }"
+      @click="projectsStore.activeTab = 'settings'"
+      title="Settings"
+    >
+      <UIcon name="i-lucide-settings" class="tab-icon" />
+    </div>
+
+    <!-- Project tabs (draggable) -->
+    <VueDraggable
+      v-model="draggableProjects"
+      class="project-tabs"
+      :animation="150"
+      item-key="id"
+      @end="onDragEnd"
+    >
+      <div
+        v-for="project in draggableProjects"
+        :key="project.id"
+        class="tab tab--project"
+        :class="{ 'tab--active': projectsStore.activeTab === project.id }"
+        @click="switchToProject(project.id)"
+      >
+        <span v-if="sessionsStore.hasActiveCards(project.id)" class="activity-dot" />
+        <span class="tab-name">{{ project.name }}</span>
+        <UButton
+          variant="ghost"
+          color="neutral"
+          size="xs"
+          icon="i-lucide-x"
+          class="tab-close"
+          :padded="false"
+          @click.stop="closeProject(project.id)"
+          title="Close project"
+        />
+      </div>
+    </VueDraggable>
 
     <!-- Add project -->
     <UButton
@@ -77,30 +86,18 @@ async function addProject() {
 
     <div class="spacer" />
 
-    <!-- Project settings -->
+    <!-- Project settings (visible when a project tab is active) -->
     <UButton
-      v-if="projectsStore.activeProject"
+      v-if="projectsStore.isProjectTab"
       variant="ghost"
       color="neutral"
       size="xs"
-      icon="i-lucide-settings"
+      icon="i-lucide-sliders-horizontal"
+      class="action-btn"
+      :padded="false"
       title="Project settings"
-      @click="emit('open-settings')"
-    >
-      Settings
-    </UButton>
-
-    <!-- Global settings -->
-    <UButton
-      variant="ghost"
-      color="neutral"
-      size="xs"
-      icon="i-lucide-globe"
-      title="Global settings"
-      @click="emit('open-global-settings')"
-    >
-      Global
-    </UButton>
+      @click="emit('open-project-settings')"
+    />
   </div>
 </template>
 
@@ -120,7 +117,6 @@ async function addProject() {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px 6px 16px;
   border-radius: 6px 6px 0 0;
   background: transparent;
   color: var(--text-secondary);
@@ -131,10 +127,32 @@ async function addProject() {
 }
 .tab:hover { background: var(--bg-tertiary); }
 .tab--active { background: var(--bg-primary); color: var(--text-primary); }
+
+.tab--pinned {
+  padding: 6px 10px;
+  flex-shrink: 0;
+}
+.tab-icon { font-size: 16px; }
+
+.project-tabs { display: flex; gap: 2px; align-items: flex-end; }
+.tab--project { padding: 6px 12px 6px 16px; }
+.activity-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
 .tab-name { pointer-events: none; }
 .tab-close { opacity: 0; transition: opacity 0.15s; -webkit-app-region: no-drag; }
 .tab:hover .tab-close { opacity: 1; }
 
 .add-tab { -webkit-app-region: no-drag; }
+.action-btn { -webkit-app-region: no-drag; }
 .spacer { flex: 1; }
 </style>

--- a/app/composables/useProjectActions.ts
+++ b/app/composables/useProjectActions.ts
@@ -1,0 +1,42 @@
+import { open } from '@tauri-apps/plugin-dialog';
+
+export function useProjectActions() {
+  const projectsStore = useProjectsStore();
+  const cardsStore = useCardsStore();
+  const pipelinesStore = usePipelinesStore();
+
+  async function addProject(): Promise<void> {
+    const selected = await open({ directory: true, multiple: false });
+    if (!selected) return;
+    const path = typeof selected === 'string' ? selected : String(selected);
+    const name = path.split('/').filter(Boolean).pop() || 'project';
+    const project = await projectsStore.addProject(name, path);
+    projectsStore.activeTab = project.id;
+    await cardsStore.loadForProject(project.id);
+    await pipelinesStore.loadForProject(project.path);
+  }
+
+  async function switchToProject(projectId: string): Promise<void> {
+    await projectsStore.setActive(projectId);
+    projectsStore.activeTab = projectId;
+    const project = projectsStore.activeProject;
+    if (project) {
+      await cardsStore.loadForProject(project.id);
+      await pipelinesStore.loadForProject(project.path);
+    }
+  }
+
+  async function closeProject(projectId: string): Promise<void> {
+    await projectsStore.removeProject(projectId);
+    const active = projectsStore.activeProject;
+    if (active) {
+      projectsStore.activeTab = active.id;
+      await cardsStore.loadForProject(active.id);
+      await pipelinesStore.loadForProject(active.path);
+    } else {
+      projectsStore.activeTab = 'home';
+    }
+  }
+
+  return { addProject, switchToProject, closeProject };
+}

--- a/app/services/database.ts
+++ b/app/services/database.ts
@@ -77,6 +77,10 @@ async function runMigrations(db: Database): Promise<void> {
   try {
     await db.execute("ALTER TABLE cards ADD COLUMN forked_from_id TEXT DEFAULT ''");
   } catch { /* column already exists */ }
+  // Migration: add tab_order for persistent project tab ordering
+  try {
+    await db.execute('ALTER TABLE projects ADD COLUMN tab_order INTEGER DEFAULT 0');
+  } catch { /* column already exists */ }
 }
 
 export async function insertProject(project: Project): Promise<void> {
@@ -91,12 +95,24 @@ export async function getAllProjects(): Promise<Project[]> {
   const d = await getDb();
   const rows = await d.select<Array<{
     id: string; name: string; path: string;
-    created_at: string; last_opened_at: string;
-  }>>('SELECT * FROM projects ORDER BY last_opened_at DESC');
+    created_at: string; last_opened_at: string; tab_order: number;
+  }>>('SELECT * FROM projects ORDER BY tab_order ASC, last_opened_at DESC');
   return rows.map(r => ({
     id: r.id, name: r.name, path: r.path,
     createdAt: r.created_at, lastOpenedAt: r.last_opened_at,
   }));
+}
+
+export async function updateProjectTabOrder(orderedIds: string[]): Promise<void> {
+  if (orderedIds.length === 0) return;
+  const d = await getDb();
+  // Single UPDATE with CASE to avoid N round-trips
+  const whenClauses = orderedIds.map((_, i) => `WHEN $${i + 1} THEN ${i}`).join(' ');
+  const placeholders = orderedIds.map((_, i) => `$${i + 1}`).join(', ');
+  await d.execute(
+    `UPDATE projects SET tab_order = CASE id ${whenClauses} END WHERE id IN (${placeholders})`,
+    orderedIds,
+  );
 }
 
 export async function updateProjectLastOpened(id: string): Promise<void> {

--- a/app/stores/projects.ts
+++ b/app/stores/projects.ts
@@ -6,6 +6,11 @@ export const useProjectsStore = defineStore('projects', () => {
   const projects = ref<Project[]>([]);
   const activeProjectId = ref<string | null>(null);
 
+  // NAV: Tracks the active tab — 'home', 'settings', or a project ID.
+  // Owned here so that sessions store can derive per-project active chat correctly.
+  const activeTab = ref<string>('home');
+  const isProjectTab = computed(() => activeTab.value !== 'home' && activeTab.value !== 'settings');
+
   const activeProject = computed(() =>
     projects.value.find(p => p.id === activeProjectId.value) || null
   );
@@ -63,5 +68,13 @@ export const useProjectsStore = defineStore('projects', () => {
     await db.updateProjectLastOpened(id);
   }
 
-  return { projects, activeProjectId, activeProject, load, addProject, removeProject, setActive };
+  async function reorderProjects(orderedIds: string[]): Promise<void> {
+    const reordered = orderedIds
+      .map(id => projects.value.find(p => p.id === id))
+      .filter((p): p is Project => p !== undefined);
+    projects.value = reordered;
+    await db.updateProjectTabOrder(orderedIds);
+  }
+
+  return { projects, activeProjectId, activeTab, isProjectTab, activeProject, load, addProject, removeProject, setActive, reorderProjects };
 });

--- a/app/stores/sessions.ts
+++ b/app/stores/sessions.ts
@@ -10,12 +10,32 @@ import { ensureMarkdownReady } from '~/services/markdown';
 
 export const useSessionsStore = defineStore('sessions', () => {
   const messages: Record<string, ChatPart[]> = reactive({});
-  const activeChatCardId = ref<string | null>(null);
+
+  // NAV: Per-project active chat — each project remembers which card's chat was open
+  const activeChatCardByProject = reactive(new Map<string, string>());
+  const activeChatCardId = computed<string | null>(() => {
+    const projectsStore = useProjectsStore();
+    if (!projectsStore.isProjectTab) return null;
+    const projectId = projectsStore.activeProjectId;
+    if (!projectId) return null;
+    return activeChatCardByProject.get(projectId) ?? null;
+  });
+
   const historyLoaded = new Set<string>();
   const _loadingHistory = ref(new Set<string>());
   const sessionConfigs: Record<string, SessionConfig> = reactive({});
   const availableCommands = ref<{ name: string; desc: string; source?: string }[]>([]);
   const sessionMetrics: Record<string, { inputTokens: number; outputTokens: number; costUsd: number; durationMs: number }> = reactive({});
+
+  // NAV: Track cardId → projectId for cross-project activity indicators
+  const cardProjectMap = reactive(new Map<string, string>());
+
+  function hasActiveCards(projectId: string): boolean {
+    for (const [cardId, pid] of cardProjectMap) {
+      if (pid === projectId && isQueryActive(cardId)) return true;
+    }
+    return false;
+  }
 
   // Track active sub-agents per card (task_started adds, result/notification removes)
   const activeSubAgents: Record<string, Set<string>> = reactive({});
@@ -285,6 +305,9 @@ export const useSessionsStore = defineStore('sessions', () => {
     const project = useProjectsStore().activeProject;
     if (!project) return;
 
+    // NAV: Register card-project association for cross-project activity indicators
+    cardProjectMap.set(cardId, project.id);
+
     await cardsStore.updateCardState(cardId, 'active');
 
     // Determine session ID for resume
@@ -404,7 +427,12 @@ export const useSessionsStore = defineStore('sessions', () => {
   }
 
   async function openChat(cardId: string): Promise<void> {
-    activeChatCardId.value = cardId;
+    const projectId = useProjectsStore().activeProjectId;
+    if (projectId) {
+      activeChatCardByProject.set(projectId, cardId);
+      // NAV: Register card-project association for cross-project activity indicators
+      cardProjectMap.set(cardId, projectId);
+    }
 
     // Seed session metrics from persisted card data (survives app restart)
     const cardsStore = useCardsStore();
@@ -452,7 +480,10 @@ export const useSessionsStore = defineStore('sessions', () => {
       }
     }
   }
-  function closeChat(): void { activeChatCardId.value = null; }
+  function closeChat(): void {
+    const projectId = useProjectsStore().activeProjectId;
+    if (projectId) activeChatCardByProject.delete(projectId);
+  }
   function isActive(cardId: string): boolean { return isQueryActive(cardId); }
   function isLoadingHistory(cardId: string): boolean { return _loadingHistory.value.has(cardId); }
 
@@ -488,6 +519,12 @@ export const useSessionsStore = defineStore('sessions', () => {
     historyLoaded.delete(cardId);
     _streamingBuffers.delete(cardId);
     _streamingRafPending.delete(cardId);
+    // NAV: Clean up per-project active chat if this card was open
+    const pid = cardProjectMap.get(cardId);
+    if (pid && activeChatCardByProject.get(pid) === cardId) {
+      activeChatCardByProject.delete(pid);
+    }
+    cardProjectMap.delete(cardId);
   }
 
   return {
@@ -496,5 +533,6 @@ export const useSessionsStore = defineStore('sessions', () => {
     appendPart, resolveActionPart, handleMeta, fireTriggerPrompt,
     send, approveToolUse, rejectToolUse,
     loadAvailableCommands, interruptSession, stopSession, openChat, closeChat, isActive, isLoadingHistory, purgeCard,
+    hasActiveCards,
   };
 });


### PR DESCRIPTION
## Summary

Reworks the tab bar navigation to support the Product Ready spec (REQ-NAV-1 through REQ-NAV-7):

- **Pinned Home & Settings tabs** — icon-only, always first/second, non-closable. Settings renders as full-screen inline page instead of modal. `activeTab` state owned by `projectsStore` for cross-store reactivity.
- **Draggable project tabs** — VueDraggable reordering with persisted tab order via `tab_order` column (single batched SQL UPDATE).
- **Activity indicators** — pulsing dot on project tabs with running agents, driven by reactive `hasActiveCards()` and a `cardProjectMap` in sessions store.
- **Per-project active chat** — `activeChatCardByProject` Map replaces global `activeChatCardId` ref. Derived computed preserves all 30+ consumer refs. Returns `null` on Home/Settings tabs. In-memory only.
- **useProjectActions composable** — consolidates `addProject`/`switchToProject`/`closeProject` from TabBar and app.vue.

## Files changed (7)

| File | Change |
|------|--------|
| `app/app.vue` | activeTab routing via store, GlobalSettings inline, composable |
| `app/components/TabBar.vue` | Pinned tabs, VueDraggable, activity dots, store-based activeTab |
| `app/components/GlobalSettings.vue` | UModal → full-screen page |
| `app/composables/useProjectActions.ts` | New — shared project navigation logic |
| `app/services/database.ts` | `tab_order` migration + batched update |
| `app/stores/projects.ts` | `activeTab`, `isProjectTab`, `reorderProjects` |
| `app/stores/sessions.ts` | `activeChatCardByProject`, `cardProjectMap`, `hasActiveCards` |

## Test plan

- [x] `pnpm test` — 14/14 pass
- [x] `pnpm build` — Nuxt production build succeeds
- [x] No new type errors (pre-existing only)
- [ ] Manual: verify pinned tabs render, project tabs drag, activity dot pulses, chat restores per project