### PR TITLE
fix(fs): add write-file permission for image attachments

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -103,9 +103,11 @@
         { "path": "$HOME/**" },
         { "path": "$APPCONFIG/**" },
         { "path": "$APPDATA/**" },
+        { "path": "$TEMP/**" },
         { "path": "/Users/**" },
         { "path": "/tmp/**" },
-        { "path": "/private/**" }
+        { "path": "/private/**" },
+        { "path": "/var/folders/**" }
       ]
     },
     {
@@ -117,6 +119,19 @@
         { "path": "/Users/**" },
         { "path": "/tmp/**" },
         { "path": "/private/**" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-write-file",
+      "allow": [
+        { "path": "$HOME/**" },
+        { "path": "$APPCONFIG/**" },
+        { "path": "$APPDATA/**" },
+        { "path": "$TEMP/**" },
+        { "path": "/Users/**" },
+        { "path": "/tmp/**" },
+        { "path": "/private/**" },
+        { "path": "/var/folders/**" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Adds missing `fs:allow-write-file` permission to Tauri ACL — required by `writeFile()` (binary writes) which uses a different internal command (`plugin:fs|write_file`) than `fs:allow-write`
- Adds `$TEMP/**` and `/var/folders/**` to `fs:allow-mkdir` and `fs:allow-write-file` scopes so macOS temp directory paths (returned by `tempDir()`) are covered

## Context

Image attachments in the integrated chat were failing with two ACL errors:
1. `Command plugin:fs|write_file not allowed by ACL` — missing `fs:allow-write-file` permission
2. `forbidden path: /var/folders/...` — macOS `tempDir()` resolves to `/var/folders/` rather than `/tmp/`

## Test plan

- [x] Paste an image in the integrated chat and send — no ACL errors
- [x] Nuxt build passes
- [x] Cargo check passes